### PR TITLE
Fix: Hide tokio import behind the async feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ extern crate stun_codec;
 extern crate rand;  
 extern crate anyhow;
 
-extern crate tokio;
 #[cfg(feature="async")]
+extern crate tokio;
 
 use stun_codec::{MessageDecoder, MessageEncoder};
 


### PR DESCRIPTION
I think that was the original intention. Anyway, without this change we're forcing users to manually import tokio even though they may only be interested in the sync version. Not great.

I'd really appreciate if you could release a new version with this fix.

Cheers